### PR TITLE
Remove confusing @SuppressLint annotations from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ be used for the ship called Lisa as _Sail_:
 ```kotlin
 class MainActivity : AppCompatActivity() {
 
-    @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -183,7 +182,6 @@ Side-note: ```kompass.main``` is a little convenience extension for ```kompass["
 
 ```kotlin
     
-    @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)


### PR DESCRIPTION
I suggest to remove the confusing `@SuppressLint("MissingSuperCall")` annotations from the `README.md`.
The super methods are called in the samples and thus basically render the LINT annotations void.  
Anyway, I would personally consider suppressing LINT warnings in samples a bad practice. I guess it was included by accident.