### PR TITLE
[73] LoginProcessingFragment stuck loading

### DIFF
--- a/android-example--fragment/src/main/java/io/sellmair/kompass/android/example/fragment/LoginProcessingFragment.kt
+++ b/android-example--fragment/src/main/java/io/sellmair/kompass/android/example/fragment/LoginProcessingFragment.kt
@@ -40,9 +40,4 @@ class LoginProcessingFragment : BaseFragment() {
         val name: TextView = view.findViewById(R.id.name)
         name.text = route.email
     }
-
-    override fun onPause() {
-        super.onPause()
-        viewModel.stop()
-    }
 }

--- a/android-example--fragment/src/main/java/io/sellmair/kompass/android/example/viewmodel/LoginProcessingViewModel.kt
+++ b/android-example--fragment/src/main/java/io/sellmair/kompass/android/example/viewmodel/LoginProcessingViewModel.kt
@@ -34,12 +34,7 @@ class LoginProcessingViewModel : ViewModel() {
         handler.postDelayed(loggedIn, 3000)
     }
 
-    fun stop() {
-        handler.removeCallbacks(loggedIn)
-    }
-
     private fun onLoginFailed() = router replaceTopWith LoginFailedRoute(email)
-
 
     private fun onLoginSuccess() = router {
         DummyService.isLoggedIn = true


### PR DESCRIPTION
Fix issue where LoginProcessingFragment gets stuck loading. 

It's actually not required to remove the Handler callback, as this will be handled correctly without the stop method in the case of both configuration change and process death. `onCleared` already does a perfect job of cleaning these up when they need to be cleaned up!